### PR TITLE
Fixed watch config in grunt file

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
                 tasks: ['uglify:directives', 'jshint']
             },
             modules: {
-                src: ['app/**/*.module.js'],
+                files: ['app/**/*.module.js'],
                 dest: 'public/js/modules.min.js'
             }
         },


### PR DESCRIPTION
Grunt Error:
Verifying property watch.modules.files exists in config...ERROR

> > Unable to process task.
> > Warning: Required config property "watch.modules.files" missing.

Fix:
Change grunt config file.. watch { modules { src: > watch { modules { files:
